### PR TITLE
适配蓝牙协议栈demo代码，修改nrf52832的MDK模板文件中，应用程序的RAM起始地址，以及可使用的RAM

### DIFF
--- a/templete_project/pca10040/template.uvprojx
+++ b/templete_project/pca10040/template.uvprojx
@@ -10,7 +10,7 @@
       <TargetName>rtthread</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060422::V5.06 update 4 (build 422)::ARMCC</pCCUsed>
+      <pCCUsed>5060750::V5.06 update 6 (build 750)::ARMCC</pCCUsed>
       <uAC6>0</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -298,13 +298,13 @@
               </OCR_RVCT8>
               <OCR_RVCT9>
                 <Type>0</Type>
-                <StartAddress>0x20001d50</StartAddress>
-                <Size>0xe2b0</Size>
+                <StartAddress>0x20004c00</StartAddress>
+                <Size>0xb400</Size>
               </OCR_RVCT9>
               <OCR_RVCT10>
                 <Type>0</Type>
-                <StartAddress>0x800000</StartAddress>
-                <Size>0x10000</Size>
+                <StartAddress>0x0</StartAddress>
+                <Size>0x0</Size>
               </OCR_RVCT10>
             </OnChipMemories>
             <RvctStartVector></RvctStartVector>


### PR DESCRIPTION
适配蓝牙协议栈demo代码，修改nrf52832的MDK模板文件中，应用程序的RAM起始地址，以及可使用的RAM

Signed-off-by: chenyingchun0312 <chenyingchun0312@163.com>